### PR TITLE
Endorsement System, New Frontend Endpoints

### DIFF
--- a/app/Enums/EndorsementType.php
+++ b/app/Enums/EndorsementType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+use App\Traits\EnumToArray;
+
+enum EndorsementType: string
+{
+    use EnumToArray;
+    
+    case DEVELOPER = 'developer';
+    case INFLUENCER = 'influencer';
+    case ORGANIZATION = 'organization';
+    case NODE_RUNNER = 'node-runner';
+    case BIG_BRAINER = 'big-brainer';
+    case SHITPOSTER = 'shitposter';
+    case ANALYST = 'analyst';
+    case CONTENT_CREATOR = 'content-creator';
+    case ARTIST = 'artist';
+    case MINER = 'miner';
+}

--- a/app/Http/Controllers/Frontend/Follow/Scopes/FollowerController.php
+++ b/app/Http/Controllers/Frontend/Follow/Scopes/FollowerController.php
@@ -27,4 +27,13 @@ class FollowerController extends Controller
             'followers' => $followers->paginate(perPage: 20),
         ]);
     }
+
+    public function all(): JsonResponse
+    {
+        $followers = auth()->user()->follows();
+
+        return response()->json([
+            'followers' => $followers->paginate(perPage: 20),
+        ]);
+    }
 }

--- a/app/Http/Controllers/Frontend/Follow/Scopes/FollowingController.php
+++ b/app/Http/Controllers/Frontend/Follow/Scopes/FollowingController.php
@@ -27,4 +27,13 @@ class FollowingController extends Controller
             'following' => $following->paginate(perPage: 20),
         ]);
     }
+
+    public function all(): JsonResponse
+    {
+        $following = auth()->user()->followers();
+
+        return response()->json([
+            'following' => $following->paginate(perPage: 20),
+        ]);
+    }
 }

--- a/app/Http/Controllers/Frontend/User/EndorsementController.php
+++ b/app/Http/Controllers/Frontend/User/EndorsementController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Frontend\User;
+
+use App\Enums\EndorsementType;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\DestroyEndorsementRequest;
+use App\Http\Requests\StoreEndorsementRequest;
+use App\Models\User;
+use App\Services\UserService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class EndorsementController extends Controller
+{
+    public function __construct(private UserService $userService)
+    {
+    }
+
+    public function index(User $twitterId): JsonResponse
+    {
+        return response()->json($twitterId->endorsementsReceived(), Response::HTTP_OK);
+    }
+
+    public function store(StoreEndorsementRequest $request): JsonResponse
+    {
+        $endorsement = $this->userService->endorseUser(
+            endorserId: auth()->user()->twitter_id, 
+            endorseeId: $request->input('twitterId'),
+            type: $request->input('type')
+        );
+
+        if ($endorsement === true) {
+            return response()->json(['message' => 'Endorsement created successfully'], Response::HTTP_CREATED);
+        } 
+
+        return response()->json(['message' => 'Endorsement already exists'], Response::HTTP_CONFLICT);
+    }
+
+    public function destroy(DestroyEndorsementRequest $request): JsonResponse
+    {
+        $endorsement = $this->userService->unendorseUser(
+            endorserId: auth()->user()->twitter_id, 
+            endorseeId: $request->input('twitterId'),
+            type: $request->input('type')
+        );
+
+        if ($endorsement === true) {
+            return response()->json(['message' => 'Endorsement deleted successfully'], Response::HTTP_OK);
+        } 
+
+        return response()->json(['message' => 'Endorsement does not exist'], Response::HTTP_NOT_FOUND);
+    }
+
+    public function types(): JsonResponse
+    {
+        return response()->json(EndorsementType::array(), Response::HTTP_OK);
+    }
+}

--- a/app/Http/Requests/DestroyEndorsementRequest.php
+++ b/app/Http/Requests/DestroyEndorsementRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DestroyEndorsementRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'type' => 'required|string',
+            'twitterId' => 'required|string',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreEndorsementRequest.php
+++ b/app/Http/Requests/StoreEndorsementRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreEndorsementRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'type' => 'required|string',
+            'twitterId' => 'required|string',
+        ];
+    }
+}

--- a/app/Models/Endorsement.php
+++ b/app/Models/Endorsement.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Endorsement extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'endorser_id',
+        'endorsee_id',
+        'endorsement_type',
+    ];
+
+    public function endorser()
+    {
+        return $this->belongsTo(User::class, 'endorser_id');
+    }
+
+    public function endorsee()
+    {
+        return $this->belongsTo(User::class, 'endorsee_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -94,6 +94,16 @@ class User extends Authenticatable
         return $this->hasMany(Tweet::class, 'user_id', 'twitter_id');
     }
 
+    public function endorsements()
+    {
+        return $this->hasMany(Endorsement::class, 'endorser_id', 'twitter_id');
+    }
+
+    public function endorsementsReceived()
+    {
+        return $this->hasMany(Endorsement::class, 'endorsee_id', 'twitter_id');
+    }
+
     public function getAvailableBalance(): int
     {
         $debits = $this->transactions()

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -3,7 +3,9 @@
 namespace App\Services;
 
 use App\Enums\ClassificationSource;
+use App\Enums\EndorsementType;
 use App\Enums\UserType;
+use App\Models\Endorsement;
 use App\Models\Follow;
 use App\Models\User;
 use Carbon\Carbon;
@@ -231,5 +233,43 @@ class UserService
     public function isFollower(User $user, User $targetUser): bool
     {
         return (Follow::where('follower_id', $targetUser->twitter_id)->where('followee_id', $user->twitter_id)->first() !== null);
+    }
+
+    public function endorseUser(string $endorserId, string $endorseeId, string $type): bool
+    {
+        $endorsement = Endorsement::query()
+            ->where('endorser_id', $endorserId)
+            ->where('endorsee_id', $endorseeId)
+            ->where('endorsement_type', $type)
+            ->first();
+
+        if ($endorsement) {
+            return false;
+        }
+
+        Endorsement::create([
+            'endorser_id' => $endorserId,
+            'endorsee_id' => $endorseeId,
+            'endorsement_type' => $type,
+        ]);
+
+        return true;
+    }
+
+    public function unendorseUser(string $endorserId, string $endorseeId, string $type): bool
+    {
+        $endorsement = Endorsement::query()
+            ->where('endorser_id', $endorserId)
+            ->where('endorsee_id', $endorseeId)
+            ->where('endorsement_type', $type)
+            ->first();
+
+        if (!$endorsement) {
+            return false;
+        }
+
+        $endorsement->delete();
+
+        return true;
     }
 }

--- a/app/Traits/EnumToArray.php
+++ b/app/Traits/EnumToArray.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Traits;
+
+trait EnumToArray
+{
+    public static function names(): array
+    {
+        return array_column(self::cases(), 'name');
+    }
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public static function array(): array
+    {
+        return array_combine(self::names(), self::values());
+    }
+}

--- a/bitcoiners.network.postman_collection.json
+++ b/bitcoiners.network.postman_collection.json
@@ -213,7 +213,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"amount\": 50\n}",
+							"raw": "{\n    \"amount\": 3000\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -261,6 +261,34 @@
 					"response": []
 				},
 				{
+					"name": "Endorse User",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"twitterId\": \"1558844336187523074\",\n    \"type\": \"developer\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost/frontend/endorse",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"path": [
+								"frontend",
+								"endorse"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Get User Details by Username",
 					"request": {
 						"method": "GET",
@@ -299,6 +327,67 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Get Endorsements",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"twitterId\": \"1558844336187523074\",\n    \"type\": \"developer\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost/frontend/user/endorsements/1558844336187523074",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"path": [
+								"frontend",
+								"user",
+								"endorsements",
+								"1558844336187523074"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Unendorse User",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"twitterId\": \"1558844336187523074\",\n    \"type\": \"developer\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost/frontend/endorse",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"path": [
+								"frontend",
+								"endorse"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},
@@ -329,6 +418,70 @@
 								"frontend",
 								"transaction",
 								"deposit"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "View Deposits",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"amount\": 100000\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost/frontend/transaction/deposit",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"path": [
+								"frontend",
+								"transaction",
+								"deposit"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "View Debits",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"amount\": 100000\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost/frontend/transaction/debit",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"path": [
+								"frontend",
+								"transaction",
+								"debit"
 							]
 						}
 					},
@@ -390,6 +543,27 @@
 							"response": []
 						},
 						{
+							"name": "Bitcoiner Followers (Auth User)",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost/frontend/follow/followers/bitcoiner",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"path": [
+										"frontend",
+										"follow",
+										"followers",
+										"bitcoiner"
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "Shitcoiner Follows (Auth User)",
 							"request": {
 								"method": "GET",
@@ -404,6 +578,27 @@
 										"frontend",
 										"follow",
 										"following",
+										"shitcoiner"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Shitcoiner Followers (Auth User)",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost/frontend/follow/followers/shitcoiner",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"path": [
+										"frontend",
+										"follow",
+										"followers",
 										"shitcoiner"
 									]
 								}
@@ -426,6 +621,67 @@
 										"follow",
 										"following",
 										"nocoiner"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Nocoiner Followers (Auth User)",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost/frontend/follow/followers/nocoiner",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"path": [
+										"frontend",
+										"follow",
+										"followers",
+										"nocoiner"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "All Follows (Auth User)",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost/frontend/follow/following",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"path": [
+										"frontend",
+										"follow",
+										"following"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "All Followers (Auth User)",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost/frontend/follow/followers",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"path": [
+										"frontend",
+										"follow",
+										"followers"
 									]
 								}
 							},
@@ -506,6 +762,43 @@
 					"path": [
 						"frontend",
 						"rates"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Endorsement Types",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "BTCPay-Sig",
+						"value": "sha256=9adf95596669e6a99943707800ea51015267bfcc45a22818bdcc6f377bc6bbfa1e666",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\"manuallyMarked\": false,\n\"deliveryId\": \"FRWuM8BzwbawewLY5pJWcc\",\n\"webhookId\": \"Mn4cZakALSkeDHYz3m14FA\",\n\"originalDeliveryId\": \"FRWuM8BzwbawewLY5pJWcc\",\n\"isRedelivery\": false,\n\"type\": \"InvoiceSettled\",\n\"timestamp\": 1662860619,\n\"storeId\": \"AFaaz6gYXM28FXNpoJiU22QUQcvMNwZutahN9jK6Swkx\",\n\"invoiceId\": \"T6VfdbEMd3rxAx2nikftgt\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost/frontend/endorsement-types",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"path": [
+						"frontend",
+						"endorsement-types"
 					]
 				}
 			},

--- a/database/migrations/2022_09_25_164212_create_endorsements_table.php
+++ b/database/migrations/2022_09_25_164212_create_endorsements_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('endorsements', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('endorser_id');
+            $table->foreignId('endorsee_id');
+            $table->string('endorsement_type');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('endorsements');
+    }
+};

--- a/routes/frontend.php
+++ b/routes/frontend.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Frontend\RatesController;
 use App\Http\Controllers\Frontend\Transaction\DebitController;
 use App\Http\Controllers\Frontend\Transaction\DepositController;
 use App\Http\Controllers\Frontend\User\AvailableBalanceController;
+use App\Http\Controllers\Frontend\User\EndorsementController;
 use App\Http\Controllers\Frontend\User\UserController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -37,11 +38,14 @@ Route::get('/random-bitcoiners', [HomeController::class, 'randomBitcoiners'])->n
 Route::get('/random-shitcoiners', [HomeController::class, 'randomShitcoiners'])->name('home.random-shitcoiners');
 Route::get('/random-nocoiners', [HomeController::class, 'randomNocoiners'])->name('home.random-nocoiners');
 Route::get('/rates', [RatesController::class, 'index'])->name('rates.index');
+Route::get('/endorsement-types', [EndorsementController::class, 'types'])->name('endorsements.types');
 
 Route::middleware('auth')->group(function () {
-    Route::get('/follow/available/{userType}', [AvailableFollowsController::class, 'index'])->name('follow.available');
-    Route::get('/follow/followers/{userType}', [FollowerController::class, 'index'])->name('follow.followers');
-    Route::get('/follow/following/{userType}', [FollowingController::class, 'index'])->name('follow.following');
+    Route::get('/follow/available/{userType}', [AvailableFollowsController::class, 'index'])->name('follow.available.type');
+    Route::get('/follow/followers/{userType}', [FollowerController::class, 'index'])->name('follow.followers.type');
+    Route::get('/follow/following/{userType}', [FollowingController::class, 'index'])->name('follow.following.type');
+    Route::get('/follow/following', [FollowingController::class, 'all'])->name('follow.following.all');
+    Route::get('/follow/followers', [FollowerController::class, 'all'])->name('follow.followers.all');
     Route::get('/follow/mass-follow', [MassFollowController::class, 'index'])->name('follow.mass-follow.index');
     Route::post('follow/mass-follow', [MassFollowController::class, 'store'])->name('follow.mass-follow.store');
     Route::get('follow/requests/completed', [FollowRequestScopeController::class, 'completed'])->name('follow.requests.completed');
@@ -57,6 +61,9 @@ Route::middleware('auth')->group(function () {
     
     Route::get('/user/auth', [UserController::class, 'auth'])->name('user.auth');
     Route::get('/user/{username}', [UserController::class, 'show'])->name('user.show');
+    Route::post('/endorse', [EndorsementController::class, 'store'])->name('user.endorse.store');
+    Route::delete('/endorse', [EndorsementController::class, 'destroy'])->name('user.endorse.destroy');
+    Route::get('/endorsements/{twitterId}', [EndorsementController::class, 'index'])->name('user.endorse.index');
 });
 
 


### PR DESCRIPTION
### Overview

**BREAKING CHANGE: Requires running `sail artisan migrate` for the new endorsement table**

Similar to LinkedIn, users can endorse each other as types of bitcoiners. A list of current endorsement types is available at the endpoint `frontend/endorsement-types`

Also included are two new Follower/Following Endpoints and updated Postman collection.

### New Follow Endpoints:

- `frontend/follow/followers` View All Authenticated User's Followers
- `frontend/follow/following` View All Users Authenticated User is Following

### Endorsement Endpoints

**Endorse a User:**

POST `frontend/endorse` 

```json
{
    "twitterId": "1558844336187523074",
    "type": "developer"
}
```

**Unendorse a User:**

DELETE `frontend/endorse` 

```json
{
    "twitterId": "1558844336187523074",
    "type": "developer"
}
```