### PR TITLE
Classification Vote System + Endpoints

### DIFF
--- a/app/Http/Controllers/Frontend/User/ClassificationVoteController.php
+++ b/app/Http/Controllers/Frontend/User/ClassificationVoteController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Frontend\User;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Services\UserService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class ClassificationVoteController extends Controller
+{
+    public function __construct(private UserService $userService)
+    {
+    }
+
+    public function index(string $username): JsonResponse
+    {
+        $user = User::where('twitter_username', $username)->firstOrFail();
+
+        return response()->json($user->getClassificationSummary(), Response::HTTP_OK);
+    }
+
+    public function auth(): JsonResponse
+    {
+        return response()->json(auth()->user()->getClassificationSummary(), Response::HTTP_OK);
+    }
+
+    public function store(string $username, string $type): JsonResponse
+    {
+        $user = User::where('twitter_username', $username)->firstOrFail();
+
+        $this->userService->voteClassifiction($user, $type);
+
+        return response()->json($user->getClassificationSummary(), Response::HTTP_OK);
+    }
+
+    public function destroy(string $username): JsonResponse
+    {
+        $user = User::where('twitter_username', $username)->firstOrFail();
+
+        $this->userService->unvoteClassifiction($user);
+
+        return response()->json($user->getClassificationSummary(), Response::HTTP_OK);
+    }
+}

--- a/app/Models/ClassificationVote.php
+++ b/app/Models/ClassificationVote.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ClassificationVote extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'classifier_id',
+        'classified_id',
+        'classification_type',
+    ];
+
+    public function classifier()
+    {
+        return $this->belongsTo(User::class, 'classifier_id');
+    }
+
+    public function classified()
+    {
+        return $this->belongsTo(User::class, 'classified_id');
+    }
+}

--- a/database/migrations/2022_09_30_011848_add_public_metrics_to_tweets_table.php
+++ b/database/migrations/2022_09_30_011848_add_public_metrics_to_tweets_table.php
@@ -14,10 +14,10 @@ return new class extends Migration
     public function up()
     {
         Schema::table('tweets', function (Blueprint $table) {
-            $table->integer('replies')->default(0);
-            $table->integer('retweets')->default(0);
-            $table->integer('likes')->default(0);
-            $table->integer('quotes')->default(0);
+            $table->integer('twitter_replies')->default(0);
+            $table->integer('twitter_retweets')->default(0);
+            $table->integer('twitter_likes')->default(0);
+            $table->integer('twitter_quotes')->default(0);
         });
     }
 
@@ -29,10 +29,10 @@ return new class extends Migration
     public function down()
     {
         Schema::table('tweets', function (Blueprint $table) {
-            $table->dropColumn('replies');
-            $table->dropColumn('retweets');
-            $table->dropColumn('likes');
-            $table->dropColumn('quotes');
+            $table->dropColumn('twitter_replies');
+            $table->dropColumn('twitter_retweets');
+            $table->dropColumn('twitter_likes');
+            $table->dropColumn('twitter_quotes');
         });
     }
 };

--- a/database/migrations/2022_10_01_194348_create_classification_votes_table.php
+++ b/database/migrations/2022_10_01_194348_create_classification_votes_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('classification_votes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('classifier_id');
+            $table->foreignId('classified_id');
+            $table->string('classification_type');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('classification_votes');
+    }
+};

--- a/routes/frontend.php
+++ b/routes/frontend.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\Frontend\RatesController;
 use App\Http\Controllers\Frontend\Transaction\DebitController;
 use App\Http\Controllers\Frontend\Transaction\DepositController;
 use App\Http\Controllers\Frontend\User\AvailableBalanceController;
+use App\Http\Controllers\Frontend\User\ClassificationVoteController;
 use App\Http\Controllers\Frontend\User\EndorsementController;
 use App\Http\Controllers\Frontend\User\RefreshUserController;
 use App\Http\Controllers\Frontend\User\UserController;
@@ -32,9 +33,9 @@ use Illuminate\Support\Facades\Route;
 */
 
 #If environment is local, Authenticate user with twitter_id 1558929312547577858
-if (app()->environment('local')) {
-    Auth::loginUsingId('1558929312547577858');
-}
+// if (app()->environment('local')) {
+//     Auth::loginUsingId('1558929312547577858');
+// }
 
 Route::get('/profile-pictures', [HomeController::class, 'profilesPictures'])->name('home.profile-pictures');
 Route::get('/random-bitcoiners', [HomeController::class, 'randomBitcoiners'])->name('home.random-bitcoiners');
@@ -69,9 +70,14 @@ Route::middleware('auth')->group(function () {
     Route::get('/user/auth', [UserController::class, 'auth'])->name('user.auth');
     Route::post('/user/{username}/refresh', [RefreshUserController::class, 'store'])->name('user.refresh.store');
     Route::get('/user/{username}', [UserController::class, 'show'])->name('user.show');
+
     Route::post('/endorse', [EndorsementController::class, 'store'])->name('user.endorse.store');
     Route::delete('/endorse', [EndorsementController::class, 'destroy'])->name('user.endorse.destroy');
     Route::get('/endorsements/{twitterId}', [EndorsementController::class, 'index'])->name('user.endorse.index');
+
+    Route::post('/classify/{username}/{type}', [ClassificationVoteController::class, 'store'])->name('user.classify.store');
+    Route::delete('/classify/{username}', [ClassificationVoteController::class, 'destroy'])->name('user.classify.destroy');
+    Route::get('/classification/{username}', [ClassificationVoteController::class, 'index'])->name('user.classify.index');
 });
 
 


### PR DESCRIPTION
### Classification Votes

If the community disagrees with the crawler's user classification, they can change classification based on a community vote.

If 10 votes are cast for a user, the classification with the highest votes will be the official classification of the user, and cannot be overwritten by the crawler.

#### Endpoints

- Cast Vote: POST `/frontend/classify/{twitter_username}/{userType}` (types: bitcoiner, shitcoiner, nocoiner)
- Retract Vote: DELETE `/frontend/classify/{twitter_username}`
- Vote Summary: GET `/frontend/classification/{twitter_username}` 

### Hotfixes

- New field available on data models `twitter_profile_image_url_high_res` which removes `_normal` from the url
