### PR TITLE
Bugfix: Cannot press on user followers/following pie charts

### DIFF
--- a/resources/js/components/UserInfoPanel/UserInfoPanel.scss
+++ b/resources/js/components/UserInfoPanel/UserInfoPanel.scss
@@ -148,7 +148,7 @@
         &.hidden {
           transition: 0.3s opacity;
           opacity: 0;
-          user-select: none;
+          pointer-events: none;
         }
       }
     }


### PR DESCRIPTION
Click/pressing on pie charts should redirect to following:

<img width="532" alt="image" src="https://user-images.githubusercontent.com/100208905/197001546-5a3d60ac-8c27-461b-ba32-70d614a6d758.png">
