### PR TITLE
Empty Follow Mempool, Crawler Overwrites

### DIFF
--- a/app/Console/Commands/ProcessFollowChunks.php
+++ b/app/Console/Commands/ProcessFollowChunks.php
@@ -2,9 +2,12 @@
 
 namespace App\Console\Commands;
 
+use App\Enums\UserType;
 use App\Models\FollowChunk;
+use App\Models\User;
 use App\Services\UserService;
 use Illuminate\Console\Command;
+use UtxoOne\TwitterUltimatePhp\Clients\UserClient;
 
 class ProcessFollowChunks extends Command
 {
@@ -35,6 +38,22 @@ class ProcessFollowChunks extends Command
 
         // Select the oldest FollowChunk that is not completed yet
         $followChunk = FollowChunk::whereNull('processed_at')->orderBy('id')->first();
+
+        // If there is no FollowChunk to process, select a user with type bitcoiner who hasn't been crawled yet
+        if (!$followChunk) {
+            $user = User::query()
+                ->where('last_crawled_at', null)
+                ->where('type', UserType::BITCOINER)
+                ->where('twitter_count_followers', '>', 1000)
+                ->where('twitter_count_followers', '<', 20000)
+                ->where('twitter_count_following', '>', 500)
+                ->first();
+
+            $twitterUserClient = new UserClient(bearerToken: config('services.twitter.bearer_token'));
+            $twitterUser = $twitterUserClient->getUserByUsername($user->twitter_username);
+            $userService = new UserService();
+            $user = $userService->processTwitterUser($twitterUser);
+        }
 
         if ($followChunk) {
             $this->info("Processing follow chunk {$followChunk->id} for user {$followChunk->user->twitter_username}");


### PR DESCRIPTION
 - If no pending crawl requests are in queue, select a new bitcoiner at random who hasn't been crawled
 - fixed a bug that was overwriting lightning verified classifications