### PR TITLE
Auth Route Redirect through React Router

### DIFF
--- a/resources/js/AppAuth.jsx
+++ b/resources/js/AppAuth.jsx
@@ -24,7 +24,6 @@ export default function AppAuth() {
       }
       catch {
         dispatch({ type: 'publicUser/set', payload: true });
-        console.log('state:', state)
       }
     }
 

--- a/resources/js/AppRoutes.jsx
+++ b/resources/js/AppRoutes.jsx
@@ -16,20 +16,19 @@ export default function AppRoutes() {
       <BrowserRouter basename="/u">
         <ScrollToTop />
         <Routes>
-          <Route path='/dashboard' element={<MainProfile key='dashboard' asDashboard />} />
           <Route path='/profile/:username' element={<MainProfile key='profile' />} />
 
-          <Route path='/auth-test' element={<AuthRoute element={<Connections initialType='followers' />} />} />
+          <Route path='/dashboard' element={<AuthRoute element={<MainProfile key='dashboard' asDashboard />} />} />
 
-          <Route path='/followers/:username' element={<Connections initialType='followers' />} />
-          <Route path='/following/:username' element={<Connections initialType='following' />} />
+          <Route path='/followers/:username' element={<AuthRoute element={<Connections initialType='followers' />} />} />
+          <Route path='/following/:username' element={<AuthRoute element={<Connections initialType='following' />} />} />
 
-          <Route path='/followers' element={<Connections initialType='followers' key='followers' />} />
-          <Route path='/following' element={<Connections initialType='following' key='following' />} />
-          <Route path='/available' element={<Connections initialType='available' key='available' />} />
+          <Route path='/followers' element={<AuthRoute element={<Connections initialType='followers' key='followers' />} />} />
+          <Route path='/following' element={<AuthRoute element={<Connections initialType='following' key='following' />} />} />
+          <Route path='/available' element={<AuthRoute element={<Connections initialType='available' key='available' />} />} />
 
-          <Route path='/campaign' element={<CampaignOverview />} />
-          <Route path='/transactions' element={<TransactionsOverview />} />
+          <Route path='/campaign' element={<AuthRoute element={<CampaignOverview />} />} />
+          <Route path='/transactions' element={<AuthRoute element={<TransactionsOverview />} />} />
           
           <Route path='*' element={<Navigate replace to="/dashboard" />} />
         </Routes>

--- a/resources/js/routes/AuthRoute.jsx
+++ b/resources/js/routes/AuthRoute.jsx
@@ -1,6 +1,18 @@
+import { useContext, useEffect } from "react";
+import AppContext from "../store/AppContext";
+
 export default function AuthRoute({ element }) {
 
-  // const [state, dispatch] = useContext(AppContext);
+  const [state] = useContext(AppContext);
+
+  const { publicUser } = state;
+
+  // If user is not logged in, redirect 
+  useEffect(() => {
+    if (publicUser) {
+      window.location.href = '/';
+    }
+  }, [publicUser]);
   
   return element;
 }

--- a/resources/js/routes/dashboard/MainProfile.jsx
+++ b/resources/js/routes/dashboard/MainProfile.jsx
@@ -104,7 +104,10 @@ export default function MainProfile({ asDashboard }) {
       setInitialLoad(true);
     }
 
+    setLoadedUser(null);
+    setUserNotFound(false);
     setInitialLoad(false);
+
     loadUserData();
   }, [asDashboard, username]);
 
@@ -285,7 +288,7 @@ export default function MainProfile({ asDashboard }) {
           <section className="user-details">
             <div ref={profilePicRef}><ProfilePicture user={userData} className='profile-pic' userNotFound={userNotFound} /></div>
             
-            { !userData && renderUserSkeleton() }
+            { !userData && !userNotFound && renderUserSkeleton() }
 
             <div className="username">{ userData?.name }</div >
             { userData && <div className="handle">@{ userData?.twitter_username }</div> }


### PR DESCRIPTION
- Auth Route Component redirects to landing page (/) if user is not logged in. Even though redirect is set on the PHP side if user is not authed, unlogging and pressing "back" or revisiting a previous auth-user only route would still show the route and crash React.
- **Bugfix:** A non-existing profile would show both skeleton loader and "not found" mesage.

<img width="653" alt="Screen Shot 2022-10-23 at 6 17 52 PM" src="https://user-images.githubusercontent.com/100208905/197425668-13605ec9-851a-4115-ae71-a0283b8c995d.png">

- **Bugfix:** On a same non-existing profile, going to the 'view dashboard' route through the hamburger menu would still show the not found profile.