### PR TITLE
- Sticky Top Search bar

### DIFF
--- a/resources/js/components/ProfilePicture/ProfilePicture.jsx
+++ b/resources/js/components/ProfilePicture/ProfilePicture.jsx
@@ -1,6 +1,6 @@
+import { useEffect, useState, useMemo } from "react"
 import axios from "axios";
 import classNames from "classnames";
-import { useEffect, useState } from "react"
 import SadFaceIcon from "../../assets/icons/SadFaceIcon";
 import UserProfileImg from "../../assets/images/UserProfile.png";
 
@@ -8,10 +8,11 @@ import './ProfilePicture.scss';
 
 export default function ProfilePicture({ user, className, userNotFound, ...props }) {
 
-  const imageSrc = user?.twitter_profile_image_url_high_res;
-
   const [imageLoaded, setImageLoaded] = useState(false);
   const [imageError, setImageError] = useState(false);
+  const [newImageSrc, setNewImgSrc] = useState(null);
+
+  const imageSrc = useMemo(() => newImageSrc || user?.twitter_profile_image_url_high_res, [newImageSrc, user])
 
   useEffect(() => {
     const loadImage = async () => {
@@ -27,7 +28,8 @@ export default function ProfilePicture({ user, className, userNotFound, ...props
       }
       catch {
         setImageError(true);
-        axios.post(`/frontend/refresh/user/${user.twitter_username}`);
+        const { data } = await axios.post(`/frontend/refresh/user/${user.twitter_username}`);
+        setNewImgSrc(data?.twitter_profile_image_url_high_res);
       }
     }
 

--- a/resources/js/routes/leaderboards/Leaderboards.scss
+++ b/resources/js/routes/leaderboards/Leaderboards.scss
@@ -9,7 +9,15 @@
     background-color: white;
     position: sticky;
     top: 0;
+    padding-top: 8px;
     z-index: 2;
+
+    .__search-bar {
+      margin: 0 auto;
+      max-width: 480px;
+      width: 95%;
+      z-index: 3;
+    }
 
     .categories {
       display: flex;
@@ -81,9 +89,8 @@
       align-items: center;
       justify-content: center;
 
-      .__search-bar {
-        width: 90%;
-        max-width: 480px;
+      &.empty {
+        height: 12px;
       }
   
       strong {
@@ -111,7 +118,7 @@
           justify-content: space-between;
           color: var(--gray-40);
           font-weight: 500;
-          gap: 12px;
+          gap: 8px;
           align-items: baseline;
           background-color: white;
 

--- a/resources/js/routes/leaderboards/SearchBar.jsx
+++ b/resources/js/routes/leaderboards/SearchBar.jsx
@@ -63,7 +63,7 @@ export default function SearchBar({ autoFocus, onClickUser, ...props }) {
               <div className="__search-bar-empty">No users found.</div>
             )}
             { results.map(result => (
-              <div key={result.twitter_username} className='__search-bar-item' onClick={() => loadUser(result.twitter_username)}>
+              <div role='button' key={result.twitter_username} className='__search-bar-item' onClick={() => loadUser(result.twitter_username)}>
                 <div className='__search-bar-username'>{ result.name }</div>
                 <div className="__search-bar-handle">@{ result.twitter_username }</div>
               </div>

--- a/resources/js/routes/leaderboards/SearchBar.scss
+++ b/resources/js/routes/leaderboards/SearchBar.scss
@@ -2,7 +2,7 @@
   border: 1px solid var(--gray-80);
   border-radius: 20px;
   background-color: white;
-  padding: 10px 12px;
+  padding: 8px 12px;
   display: flex;
   position: relative;
   display: flex;
@@ -31,8 +31,9 @@
   }
 
   &-close {
-    font-size: 22px;
     color: var(--gray-50);
+    font-size: 22px;
+    line-height: 18px;
   }
 
   &.results-visible {
@@ -71,10 +72,11 @@
   }
 
   &-item {
-    margin: 0 4px;
+    padding: 8px 6px;
+    border-radius: 4px;
 
-    &:not(:last-child) {
-      margin-bottom: 16px;
+    &:hover {
+      background-color: var(--gray-90);
     }
   }
   


### PR DESCRIPTION
- Sticky Top Search bar
- Add "Skill" as a tab and allow filtering by endorsement

<img width="376" alt="Screen Shot 2022-11-25 at 1 12 42 AM" src="https://user-images.githubusercontent.com/100208905/203923932-0d083990-b41c-49ee-9da8-85eee2267374.png">

- Fix bug where users cannot be clicked on desktop (now shows hover over item):

<img width="588" alt="Screen Shot 2022-11-25 at 1 15 41 AM" src="https://user-images.githubusercontent.com/100208905/203923960-9abc4025-09aa-416c-9880-2115b166c248.png">

- Fix ranges of bitcoiners:

<img width="603" alt="image" src="https://user-images.githubusercontent.com/100208905/203924025-52db2fd4-f2b3-4d90-a309-1564e1b5f04d.png">

- Profile pictures are reloaded when they fail in batch
